### PR TITLE
Implement SIMD optimizations for BitPacker4x on aarch64

### DIFF
--- a/src/bitpacker1x.rs
+++ b/src/bitpacker1x.rs
@@ -23,10 +23,6 @@ mod scalar {
         el << N
     }
 
-    fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
-        base | (to_shift << N)
-    }
-
     fn op_or(left: DataType, right: DataType) -> DataType {
         left | right
     }

--- a/src/bitpacker1x.rs
+++ b/src/bitpacker1x.rs
@@ -23,6 +23,10 @@ mod scalar {
         el << N
     }
 
+    fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
+        base | (to_shift << N)
+    }
+
     fn op_or(left: DataType, right: DataType) -> DataType {
         left | right
     }

--- a/src/bitpacker1x.rs
+++ b/src/bitpacker1x.rs
@@ -15,12 +15,12 @@ mod scalar {
         el as u32
     }
 
-    fn right_shift_32(el: DataType, shift: i32) -> DataType {
-        el >> shift
+    fn right_shift_32<const N: i32>(el: DataType) -> DataType {
+        el >> N
     }
 
-    fn left_shift_32(el: DataType, shift: i32) -> DataType {
-        el << shift
+    fn left_shift_32<const N: i32>(el: DataType) -> DataType {
+        el << N
     }
 
     fn op_or(left: DataType, right: DataType) -> DataType {

--- a/src/bitpacker4x.rs
+++ b/src/bitpacker4x.rs
@@ -74,7 +74,7 @@ mod sse3 {
 }
 
 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-mod aarch64 {
+mod neon {
 
     use super::BLOCK_LEN;
     use crate::Available;
@@ -262,7 +262,7 @@ impl BitPacker for BitPacker4x {
         }
         #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         {
-            if aarch64::UnsafeBitPackerImpl::available() {
+            if neon::UnsafeBitPackerImpl::available() {
                 return BitPacker4x(InstructionSet::NEON);
             }
         }
@@ -278,7 +278,7 @@ impl BitPacker for BitPacker4x {
                 }
                 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
                 InstructionSet::NEON => {
-                    aarch64::UnsafeBitPackerImpl::compress(decompressed, compressed, num_bits)
+                    neon::UnsafeBitPackerImpl::compress(decompressed, compressed, num_bits)
                 }
                 InstructionSet::Scalar => {
                     scalar::UnsafeBitPackerImpl::compress(decompressed, compressed, num_bits)
@@ -304,7 +304,7 @@ impl BitPacker for BitPacker4x {
                     num_bits,
                 ),
                 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-                InstructionSet::NEON => aarch64::UnsafeBitPackerImpl::compress_sorted(
+                InstructionSet::NEON => neon::UnsafeBitPackerImpl::compress_sorted(
                     initial,
                     decompressed,
                     compressed,
@@ -329,7 +329,7 @@ impl BitPacker for BitPacker4x {
                 }
                 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
                 InstructionSet::NEON => {
-                    aarch64::UnsafeBitPackerImpl::decompress(compressed, decompressed, num_bits)
+                    neon::UnsafeBitPackerImpl::decompress(compressed, decompressed, num_bits)
                 }
                 InstructionSet::Scalar => {
                     scalar::UnsafeBitPackerImpl::decompress(compressed, decompressed, num_bits)
@@ -355,7 +355,7 @@ impl BitPacker for BitPacker4x {
                     num_bits,
                 ),
                 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-                InstructionSet::NEON => aarch64::UnsafeBitPackerImpl::decompress_sorted(
+                InstructionSet::NEON => neon::UnsafeBitPackerImpl::decompress_sorted(
                     initial,
                     compressed,
                     decompressed,
@@ -377,7 +377,7 @@ impl BitPacker for BitPacker4x {
                 #[cfg(target_arch = "x86_64")]
                 InstructionSet::SSE3 => sse3::UnsafeBitPackerImpl::num_bits(decompressed),
                 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-                InstructionSet::NEON => aarch64::UnsafeBitPackerImpl::num_bits(decompressed),
+                InstructionSet::NEON => neon::UnsafeBitPackerImpl::num_bits(decompressed),
                 InstructionSet::Scalar => scalar::UnsafeBitPackerImpl::num_bits(decompressed),
             }
         }
@@ -392,7 +392,7 @@ impl BitPacker for BitPacker4x {
                 }
                 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
                 InstructionSet::NEON => {
-                    aarch64::UnsafeBitPackerImpl::num_bits_sorted(initial, decompressed)
+                    neon::UnsafeBitPackerImpl::num_bits_sorted(initial, decompressed)
                 }
                 InstructionSet::Scalar => {
                     scalar::UnsafeBitPackerImpl::num_bits_sorted(initial, decompressed)
@@ -428,9 +428,9 @@ mod tests {
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     #[test]
     fn test_compatible_neon() {
-        use super::aarch64;
-        if aarch64::UnsafeBitPackerImpl::available() {
-            test_util_compatible::<scalar::UnsafeBitPackerImpl, aarch64::UnsafeBitPackerImpl>(
+        use super::neon;
+        if neon::UnsafeBitPackerImpl::available() {
+            test_util_compatible::<scalar::UnsafeBitPackerImpl, neon::UnsafeBitPackerImpl>(
                 BLOCK_LEN,
             );
         }

--- a/src/bitpacker4x.rs
+++ b/src/bitpacker4x.rs
@@ -119,10 +119,6 @@ mod aarch64 {
         let base = vdupq_laneq_u32(prev, 3);
         let zero = vdupq_n_u32(0);
         let a__b__c__d_ = delta;
-        //let ___a__b__c_ = vextq_u32(zero, a__b__c__d_, 3);
-        //let a__ab_bc_cd = vaddq_u32(a__b__c__d_, ___a__b__c_);
-        //let ______a__bc = std::arch::aarch64::vpaddq_u32(zero, ___a__b__c_);
-        //let a_ab_abc_abcd = vaddq_u32(a__ab_bc_cd, ______a__bc);
         let ______a__b_ = vextq_u32(zero, a__b__c__d_, 2);
         let a__b__ca_db = vaddq_u32(______a__b_, a__b__c__d_);
         let ___a__b__ca = vextq_u32(zero, a__b__ca_db, 3);

--- a/src/bitpacker4x.rs
+++ b/src/bitpacker4x.rs
@@ -86,7 +86,7 @@ mod neon {
     use std::arch::aarch64::vshrq_n_u32 as right_shift_32;
     use std::arch::aarch64::vsliq_n_u32 as left_shift_insert_32;
     use std::arch::aarch64::{
-        vaddq_u32, vdupq_laneq_u32, vdupq_n_u32, vextq_u32, vgetq_lane_u32, vld1q_u32, vst1q_u32,
+        vaddq_u32, vdupq_laneq_u32, vdupq_n_u32, vextq_u32, vld1q_u32, vmaxvq_u32, vst1q_u32,
         vsubq_u32,
     };
     #[target_feature(enable = "neon")]
@@ -109,11 +109,9 @@ mod neon {
     #[allow(non_snake_case)]
     #[inline]
     unsafe fn or_collapse_to_u32(accumulator: DataType) -> u32 {
-        let a__b__c__d_ = accumulator;
-        let c__d__b__a_ = vextq_u32(a__b__c__d_, a__b__c__d_, 2);
-        let ca_db_ca_db = op_or(a__b__c__d_, c__d__b__a_);
-        let db_ca_db_ca = vextq_u32(ca_db_ca_db, ca_db_ca_db, 1);
-        vgetq_lane_u32(op_or(ca_db_ca_db, db_ca_db_ca), 0)
+        // NB: this function computes the max instead of ORing the vector components together.
+        // In terms of overall behavior this is equivalent since the next instruction will be clz.
+        vmaxvq_u32(accumulator)
     }
 
     #[target_feature(enable = "neon")]

--- a/src/bitpacker4x.rs
+++ b/src/bitpacker4x.rs
@@ -76,6 +76,7 @@ mod aarch64 {
     use std::arch::aarch64::vorrq_u32 as op_or;
     use std::arch::aarch64::vshlq_n_u32 as left_shift_32;
     use std::arch::aarch64::vshrq_n_u32 as right_shift_32;
+    use std::arch::aarch64::vsliq_n_u32 as left_shift_insert_32;
     use std::arch::aarch64::{
         vaddq_u32, vdupq_laneq_u32, vdupq_n_u32, vextq_u32, vgetq_lane_u32, vld1q_u32, vst1q_u32,
         vsubq_u32,
@@ -153,6 +154,15 @@ mod scalar {
 
     fn left_shift_32<const N: i32>(el: DataType) -> DataType {
         [el[0] << N, el[1] << N, el[2] << N, el[3] << N]
+    }
+
+    fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
+        [
+            base[0] | (to_shift[0] << N),
+            base[1] | (to_shift[1] << N),
+            base[2] | (to_shift[2] << N),
+            base[3] | (to_shift[3] << N),
+        ]
     }
 
     fn op_or(left: DataType, right: DataType) -> DataType {

--- a/src/bitpacker4x.rs
+++ b/src/bitpacker4x.rs
@@ -24,6 +24,11 @@ mod sse3 {
         _mm_sub_epi32,
     };
 
+    #[inline]
+    unsafe fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
+        op_or(base, left_shift_32::<N>(to_shift))
+    }
+
     #[allow(non_snake_case)]
     #[inline]
     unsafe fn or_collapse_to_u32(accumulator: DataType) -> u32 {

--- a/src/bitpacker8x.rs
+++ b/src/bitpacker8x.rs
@@ -86,29 +86,29 @@ mod scalar {
         [el as u32; 8]
     }
 
-    fn right_shift_32(el: DataType, shift: i32) -> DataType {
+    fn right_shift_32<const N: i32>(el: DataType) -> DataType {
         [
-            el[0] >> shift,
-            el[1] >> shift,
-            el[2] >> shift,
-            el[3] >> shift,
-            el[4] >> shift,
-            el[5] >> shift,
-            el[6] >> shift,
-            el[7] >> shift,
+            el[0] >> N,
+            el[1] >> N,
+            el[2] >> N,
+            el[3] >> N,
+            el[4] >> N,
+            el[5] >> N,
+            el[6] >> N,
+            el[7] >> N,
         ]
     }
 
-    fn left_shift_32(el: DataType, shift: i32) -> DataType {
+    fn left_shift_32<const N: i32>(el: DataType) -> DataType {
         [
-            el[0] << shift,
-            el[1] << shift,
-            el[2] << shift,
-            el[3] << shift,
-            el[4] << shift,
-            el[5] << shift,
-            el[6] << shift,
-            el[7] << shift,
+            el[0] << N,
+            el[1] << N,
+            el[2] << N,
+            el[3] << N,
+            el[4] << N,
+            el[5] << N,
+            el[6] << N,
+            el[7] << N,
         ]
     }
 

--- a/src/bitpacker8x.rs
+++ b/src/bitpacker8x.rs
@@ -25,11 +25,6 @@ mod avx2 {
         _mm256_slli_si256, _mm256_srli_si256, _mm256_sub_epi32,
     };
 
-    #[inline]
-    unsafe fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
-        op_or(base, left_shift_32::<N>(to_shift))
-    }
-
     #[allow(non_snake_case)]
     unsafe fn or_collapse_to_u32(accumulator: DataType) -> u32 {
         let a__b__c__d__e__f__g__h_ = accumulator;
@@ -114,19 +109,6 @@ mod scalar {
             el[5] << N,
             el[6] << N,
             el[7] << N,
-        ]
-    }
-
-    fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
-        [
-            base[0] | (to_shift[0] << N),
-            base[1] | (to_shift[1] << N),
-            base[2] | (to_shift[2] << N),
-            base[3] | (to_shift[3] << N),
-            base[4] | (to_shift[4] << N),
-            base[5] | (to_shift[5] << N),
-            base[6] | (to_shift[6] << N),
-            base[7] | (to_shift[7] << N),
         ]
     }
 

--- a/src/bitpacker8x.rs
+++ b/src/bitpacker8x.rs
@@ -112,6 +112,19 @@ mod scalar {
         ]
     }
 
+    fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
+        [
+            base[0] | (to_shift[0] << N),
+            base[1] | (to_shift[1] << N),
+            base[2] | (to_shift[2] << N),
+            base[3] | (to_shift[3] << N),
+            base[4] | (to_shift[4] << N),
+            base[5] | (to_shift[5] << N),
+            base[6] | (to_shift[6] << N),
+            base[7] | (to_shift[7] << N),
+        ]
+    }
+
     fn op_or(left: DataType, right: DataType) -> DataType {
         [
             left[0] | right[0],

--- a/src/bitpacker8x.rs
+++ b/src/bitpacker8x.rs
@@ -25,6 +25,11 @@ mod avx2 {
         _mm256_slli_si256, _mm256_srli_si256, _mm256_sub_epi32,
     };
 
+    #[inline]
+    unsafe fn left_shift_insert_32<const N: i32>(base: DataType, to_shift: DataType) -> DataType {
+        op_or(base, left_shift_32::<N>(to_shift))
+    }
+
     #[allow(non_snake_case)]
     unsafe fn or_collapse_to_u32(accumulator: DataType) -> u32 {
         let a__b__c__d__e__f__g__h_ = accumulator;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,14 +51,18 @@ macro_rules! pack_unpack_with_bits {
                         if remaining <= NUM_BITS {
                             store_unaligned(output_ptr, out_register);
                             output_ptr = output_ptr.offset(1);
-                            if remaining < NUM_BITS {
+                            if 0 < remaining && remaining < NUM_BITS {
                                 out_register = right_shift_32::<{remaining as i32}>(in_register);
                             }
                         }
                     }
                 }
                 let in_register: DataType = delta_computer.transform(load_unaligned(input_ptr.add(31)));
-                let shifted = left_shift_32::<{32 - NUM_BITS as i32}>(in_register);
+                let shifted = if 32 - NUM_BITS > 0 {
+                    left_shift_32::<{32 - NUM_BITS as i32}>(in_register)
+                } else {
+                    in_register
+                };
                 out_register = op_or(out_register, shifted);
                 store_unaligned(output_ptr, out_register);
 
@@ -87,9 +91,11 @@ macro_rules! pack_unpack_with_bits {
                         const inner_cursor: usize = (i * NUM_BITS) % 32;
                         const inner_capacity: usize = 32 - inner_cursor;
 
-                        // LLVM will not emit the shift operand if
-                        // `inner_cursor` is 0.
-                        let shifted_in_register = right_shift_32::<{inner_cursor as i32}>(in_register);
+                        let shifted_in_register = if inner_cursor != 0 {
+                            right_shift_32::<{inner_cursor as i32}>(in_register)
+                        } else {
+                            in_register
+                        };
                         let mut out_register: DataType = op_and(shifted_in_register, mask);
 
                         // We consumed our current quadruplets entirely.
@@ -101,7 +107,11 @@ macro_rules! pack_unpack_with_bits {
                             // This quadruplets is actually cutting one of
                             // our `DataType`. We need to read the next one.
                             if inner_capacity < NUM_BITS {
-                                let shifted = left_shift_32::<{inner_capacity as i32}>(in_register);
+                                let shifted = if inner_capacity != 0 {
+                                    left_shift_32::<{inner_capacity as i32}>(in_register)
+                                } else {
+                                    in_register
+                                };
                                 let masked = op_and(shifted, mask);
                                 out_register = op_or(out_register, masked);
                             }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,6 +12,7 @@ macro_rules! pack_unpack_with_bits {
                 set1,
                 right_shift_32,
                 left_shift_32,
+                left_shift_insert_32,
                 op_or,
                 op_and,
                 load_unaligned,
@@ -42,8 +43,7 @@ macro_rules! pack_unpack_with_bits {
 
                         out_register =
                             if inner_cursor > 0 {
-                                let shifted = left_shift_32::<{inner_cursor as i32}>(in_register);
-                                op_or(out_register, shifted)
+                                left_shift_insert_32::<{inner_cursor as i32}>(out_register, in_register)
                             } else {
                                 in_register
                             };
@@ -58,12 +58,11 @@ macro_rules! pack_unpack_with_bits {
                     }
                 }
                 let in_register: DataType = delta_computer.transform(load_unaligned(input_ptr.add(31)));
-                let shifted = if 32 - NUM_BITS > 0 {
-                    left_shift_32::<{32 - NUM_BITS as i32}>(in_register)
+                out_register = if 32 - NUM_BITS > 0 {
+                    left_shift_insert_32::<{32 - NUM_BITS as i32}>(out_register, in_register)
                 } else {
-                    in_register
+                    op_or(out_register, in_register)
                 };
-                out_register = op_or(out_register, shifted);
                 store_unaligned(output_ptr, out_register);
 
                 NUM_BYTES_PER_BLOCK

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,7 +42,7 @@ macro_rules! pack_unpack_with_bits {
 
                         out_register =
                             if inner_cursor > 0 {
-                                let shifted = left_shift_32(in_register, inner_cursor as i32);
+                                let shifted = left_shift_32::<{inner_cursor as i32}>(in_register);
                                 op_or(out_register, shifted)
                             } else {
                                 in_register
@@ -52,13 +52,13 @@ macro_rules! pack_unpack_with_bits {
                             store_unaligned(output_ptr, out_register);
                             output_ptr = output_ptr.offset(1);
                             if remaining < NUM_BITS {
-                                out_register = right_shift_32(in_register, remaining as i32);
+                                out_register = right_shift_32::<{remaining as i32}>(in_register);
                             }
                         }
                     }
                 }
                 let in_register: DataType = delta_computer.transform(load_unaligned(input_ptr.add(31)));
-                let shifted = left_shift_32(in_register, 32 - NUM_BITS as i32);
+                let shifted = left_shift_32::<{32 - NUM_BITS as i32}>(in_register);
                 out_register = op_or(out_register, shifted);
                 store_unaligned(output_ptr, out_register);
 
@@ -89,7 +89,7 @@ macro_rules! pack_unpack_with_bits {
 
                         // LLVM will not emit the shift operand if
                         // `inner_cursor` is 0.
-                        let shifted_in_register = right_shift_32(in_register, inner_cursor as i32);
+                        let shifted_in_register = right_shift_32::<{inner_cursor as i32}>(in_register);
                         let mut out_register: DataType = op_and(shifted_in_register, mask);
 
                         // We consumed our current quadruplets entirely.
@@ -101,7 +101,7 @@ macro_rules! pack_unpack_with_bits {
                             // This quadruplets is actually cutting one of
                             // our `DataType`. We need to read the next one.
                             if inner_capacity < NUM_BITS {
-                                let shifted = left_shift_32(in_register, inner_capacity as i32);
+                                let shifted = left_shift_32::<{inner_capacity as i32}>(in_register);
                                 let masked = op_and(shifted, mask);
                                 out_register = op_or(out_register, masked);
                             }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,7 +12,6 @@ macro_rules! pack_unpack_with_bits {
                 set1,
                 right_shift_32,
                 left_shift_32,
-                left_shift_insert_32,
                 op_or,
                 op_and,
                 load_unaligned,
@@ -43,7 +42,7 @@ macro_rules! pack_unpack_with_bits {
 
                         out_register =
                             if inner_cursor > 0 {
-                                left_shift_insert_32::<{inner_cursor as i32}>(out_register, in_register)
+                                op_or(out_register, left_shift_32::<{inner_cursor as i32}>(in_register))
                             } else {
                                 in_register
                             };
@@ -59,7 +58,7 @@ macro_rules! pack_unpack_with_bits {
                 }
                 let in_register: DataType = delta_computer.transform(load_unaligned(input_ptr.add(31)));
                 out_register = if 32 - NUM_BITS > 0 {
-                    left_shift_insert_32::<{32 - NUM_BITS as i32}>(out_register, in_register)
+                    op_or(out_register, left_shift_32::<{32 - NUM_BITS as i32}>(in_register))
                 } else {
                     op_or(out_register, in_register)
                 };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -121,8 +121,8 @@ fn test_util_compress_decompress_delta<TBitPacker: UnsafeBitPacker>(
                     "Failed at index {}, for expect_num_bits {}, \nORIGINAL {:?} \nRESULT {:?}",
                     i,
                     expected_num_bits,
-                    &original[..i + 5],
-                    &result[..i + 5]
+                    &original[..std::cmp::min(i + 5, original.len())],
+                    &result[..std::cmp::min(i + 5, result.len())]
                 );
             }
         }


### PR DESCRIPTION
A few smaller changes to the macros:
* Pass N value for shifts as a const generic. The simd packages use a legacy const generic syntax that allows these values to be passed as regular arguments, but functions outside those packages cannot implement the same interface. Passing the values as const generic arguments may also speed up scalar implementations if the target architecture has left/right shift immediate instructions.
* Add `left_shift_insert_32` to the interface used by the implementation macros as NEON has an instruction that performs exactly this operation.

The `neon` implementation of `or_collapse_to_u32()` does not actually perform an OR, but instead takes the maximum value. This is substantially faster (a single instruction) and computing the full OR does not matter as the next instruction takes the count of leading zeros.

Benchmark figures below are collected on an M1 MacBook Air. Wins and losses are pretty modest except for compress
delta which gets way faster. Graviton hosts aren't offered as part of the AWS free tier so I haven't tried this on that yet.

A few observations about the M1 results:
* The wins in the compress-delta path appear to be a result of reducing dependencies across instructions (1 subq >> 4 sub).
* Some of these operations are already partially vectorized by the compiler. For instance, decompression paths often use 64-bit or 128-bit vector operations instead of u32 operations and `num_bits()` is entirely vectorized into 16 `ldp` instructions (256 bit load) and 31 `orrb.16b` instructions.
* The M1 processor can decode many instructions in parallel and this code is largely branchless so vectorizing to reduce instruction count does not help that much, at least in a microbenchmark.

```
BitPacker4x/decompress-1                                                                            
                        time:   [72.860 ns 72.875 ns 72.894 ns]
                        thrpt:  [17.560 Gelem/s 17.564 Gelem/s 17.568 Gelem/s]
                 change:
                        time:   [-1.7626% -1.6976% -1.6413%] (p = 0.00 < 0.05)
                        thrpt:  [+1.6687% +1.7269% +1.7942%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  7 (7.00%) high severe

BitPacker4x/decompress-delta-1                                                                            
                        time:   [88.717 ns 89.072 ns 89.635 ns]
                        thrpt:  [14.280 Gelem/s 14.370 Gelem/s 14.428 Gelem/s]
                 change:
                        time:   [-3.8478% -3.4636% -2.8807%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9661% +3.5879% +4.0018%]
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  17 (17.00%) high severe

BitPacker4x/compress-1  time:   [134.46 ns 134.70 ns 134.94 ns]                                   
                        thrpt:  [9.4854 Gelem/s 9.5023 Gelem/s 9.5195 Gelem/s]
                 change:
                        time:   [+0.3742% +0.6982% +1.0038%] (p = 0.00 < 0.05)
                        thrpt:  [-0.9938% -0.6934% -0.3728%]
                        Change within noise threshold.

BitPacker4x/compress-delta-1                                                                            
                        time:   [155.85 ns 156.15 ns 156.44 ns]
                        thrpt:  [8.1818 Gelem/s 8.1973 Gelem/s 8.2130 Gelem/s]
                 change:
                        time:   [-54.493% -54.397% -54.289%] (p = 0.00 < 0.05)
                        thrpt:  [+118.77% +119.28% +119.75%]
                        Performance has improved.

BitPacker4x/decompress-15                                                                            
                        time:   [106.53 ns 106.61 ns 106.70 ns]
                        thrpt:  [11.996 Gelem/s 12.006 Gelem/s 12.015 Gelem/s]
                 change:
                        time:   [-0.7996% -0.7203% -0.6392%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6433% +0.7255% +0.8061%]
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe

BitPacker4x/decompress-delta-15                                                                            
                        time:   [110.40 ns 110.48 ns 110.59 ns]
                        thrpt:  [11.574 Gelem/s 11.586 Gelem/s 11.595 Gelem/s]
                 change:
                        time:   [-8.6616% -8.4134% -8.2071%] (p = 0.00 < 0.05)
                        thrpt:  [+8.9409% +9.1863% +9.4830%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

BitPacker4x/compress-15 time:   [137.07 ns 137.39 ns 137.67 ns]                                    
                        thrpt:  [9.2974 Gelem/s 9.3166 Gelem/s 9.3380 Gelem/s]
                 change:
                        time:   [-5.8697% -5.6046% -5.3255%] (p = 0.00 < 0.05)
                        thrpt:  [+5.6251% +5.9373% +6.2357%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

BitPacker4x/compress-delta-15                                                                            
                        time:   [164.59 ns 164.88 ns 165.17 ns]
                        thrpt:  [7.7498 Gelem/s 7.7632 Gelem/s 7.7771 Gelem/s]
                 change:
                        time:   [-54.069% -53.981% -53.902%] (p = 0.00 < 0.05)
                        thrpt:  [+116.93% +117.30% +117.72%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

BitPacker4x/decompress-31                                                                            
                        time:   [145.16 ns 145.30 ns 145.45 ns]
                        thrpt:  [8.8004 Gelem/s 8.8094 Gelem/s 8.8181 Gelem/s]
                 change:
                        time:   [+0.1781% +0.2889% +0.3998%] (p = 0.00 < 0.05)
                        thrpt:  [-0.3982% -0.2881% -0.1778%]
                        Change within noise threshold.

BitPacker4x/decompress-delta-31                                                                            
                        time:   [97.615 ns 97.686 ns 97.765 ns]
                        thrpt:  [13.093 Gelem/s 13.103 Gelem/s 13.113 Gelem/s]
                 change:
                        time:   [+3.7266% +3.8473% +4.0079%] (p = 0.00 < 0.05)
                        thrpt:  [-3.8535% -3.7048% -3.5927%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

BitPacker4x/compress-31 time:   [144.11 ns 144.29 ns 144.45 ns]                                    
                        thrpt:  [8.8609 Gelem/s 8.8712 Gelem/s 8.8819 Gelem/s]
                 change:
                        time:   [-8.7062% -8.4841% -8.2847%] (p = 0.00 < 0.05)
                        thrpt:  [+9.0330% +9.2707% +9.5365%]
                        Performance has improved.

BitPacker4x/compress-delta-31                                                                            
                        time:   [151.16 ns 151.37 ns 151.58 ns]
                        thrpt:  [8.4442 Gelem/s 8.4561 Gelem/s 8.4681 Gelem/s]
                 change:
                        time:   [-42.729% -42.458% -42.269%] (p = 0.00 < 0.05)
                        thrpt:  [+73.217% +73.787% +74.610%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

```