### PR TITLE
bench: delta benchmark doesn't use {de,}compress_sorted

### DIFF
--- a/src/bitpacking_bench.rs
+++ b/src/bitpacking_bench.rs
@@ -106,9 +106,9 @@ fn bench_decompress_delta_util<TBitPacker: BitPacker + 'static>(
         let start = i * TBitPacker::BLOCK_LEN;
         let stop = start + TBitPacker::BLOCK_LEN;
         let block = &original_values[start..stop];
-        let num_bits = bitpacker.num_bits(block);
+        let num_bits = bitpacker.num_bits_sorted(0, block);
         num_bits_vec.push(num_bits);
-        bitpacker.compress(block, &mut compressed[offset..], num_bits);
+        bitpacker.compress_sorted(0, block, &mut compressed[offset..], num_bits);
         offset += (num_bits as usize) * TBitPacker::BLOCK_LEN / 8;
     }
     let mut result: Vec<u32> = vec![0u32; original_values.len()];
@@ -116,7 +116,7 @@ fn bench_decompress_delta_util<TBitPacker: BitPacker + 'static>(
         let mut offset = 0;
         for (i, num_bits) in num_bits_vec.iter().cloned().enumerate() {
             let dest_block = &mut result[i * TBitPacker::BLOCK_LEN..][..TBitPacker::BLOCK_LEN];
-            bitpacker.decompress(&compressed[offset..], dest_block, num_bits);
+            bitpacker.decompress_sorted(0, &compressed[offset..], dest_block, num_bits);
             offset += (num_bits as usize) * TBitPacker::BLOCK_LEN / 8;
         }
     });


### PR DESCRIPTION
Thanks for creating this library!

I was banging my head against the wall trying to reproduce the decompression numbers for delta encoding from the README. 😅 Turns out `decompress_sorted` is slower than what is reported now (but more space efficient!), because the benchmarks accidentally do not call that the sorted variant.

I didn't update the README since my x86 test box is an `Intel(R) Xeon(R) E-2288G CPU @ 3.70GHz`, so all the numbers would change. I'd be happy to regenerate all the numbers on that box and update the README if you'd like!

Out of curiosity, I grepped in tantivy to see where this library was used. I guess it's not used anymore? Would love to know why! Cheers.

@fulmicoton 