### PR TITLE
add support for encoding delta-1

### DIFF
--- a/src/bitpacker1x.rs
+++ b/src/bitpacker1x.rs
@@ -43,6 +43,14 @@ mod scalar {
         offset.wrapping_add(delta)
     }
 
+    fn add(left: DataType, right: DataType) -> DataType {
+        left.wrapping_add(right)
+    }
+
+    fn sub(left: DataType, right: DataType) -> DataType {
+        left.wrapping_sub(right)
+    }
+
     // The `cfg(any(debug, not(debug)))` is here to put an attribute that has no effect.
     //
     // For other bitpacker, we enable specific CPU instruction set, but for the
@@ -91,6 +99,23 @@ impl BitPacker for BitPacker1x {
         }
     }
 
+    fn compress_strictly_sorted(
+        &self,
+        initial: Option<u32>,
+        decompressed: &[u32],
+        compressed: &mut [u8],
+        num_bits: u8,
+    ) -> usize {
+        unsafe {
+            scalar::UnsafeBitPackerImpl::compress_strictly_sorted(
+                initial,
+                decompressed,
+                compressed,
+                num_bits,
+            )
+        }
+    }
+
     fn decompress(&self, compressed: &[u8], decompressed: &mut [u32], num_bits: u8) -> usize {
         unsafe { scalar::UnsafeBitPackerImpl::decompress(compressed, decompressed, num_bits) }
     }
@@ -112,11 +137,32 @@ impl BitPacker for BitPacker1x {
         }
     }
 
+    fn decompress_strictly_sorted(
+        &self,
+        initial: Option<u32>,
+        compressed: &[u8],
+        decompressed: &mut [u32],
+        num_bits: u8,
+    ) -> usize {
+        unsafe {
+            scalar::UnsafeBitPackerImpl::decompress_strictly_sorted(
+                initial,
+                compressed,
+                decompressed,
+                num_bits,
+            )
+        }
+    }
+
     fn num_bits(&self, decompressed: &[u32]) -> u8 {
         unsafe { scalar::UnsafeBitPackerImpl::num_bits(decompressed) }
     }
 
     fn num_bits_sorted(&self, initial: u32, decompressed: &[u32]) -> u8 {
         unsafe { scalar::UnsafeBitPackerImpl::num_bits_sorted(initial, decompressed) }
+    }
+
+    fn num_bits_strictly_sorted(&self, initial: Option<u32>, decompressed: &[u32]) -> u8 {
+        unsafe { scalar::UnsafeBitPackerImpl::num_bits_strictly_sorted(initial, decompressed) }
     }
 }

--- a/src/bitpacker4x_simple.rs
+++ b/src/bitpacker4x_simple.rs
@@ -77,6 +77,24 @@ mod scalar {
         [el0, el1, el2, el3]
     }
 
+    fn add(left: DataType, right: DataType) -> DataType {
+        [
+            left[0].wrapping_add(right[0]),
+            left[1].wrapping_add(right[1]),
+            left[2].wrapping_add(right[2]),
+            left[3].wrapping_add(right[3]),
+        ]
+    }
+
+    fn sub(left: DataType, right: DataType) -> DataType {
+        [
+            left[0].wrapping_sub(right[0]),
+            left[1].wrapping_sub(right[1]),
+            left[2].wrapping_sub(right[2]),
+            left[3].wrapping_sub(right[3]),
+        ]
+    }
+
     declare_bitpacker_simple!(cfg(any(debug, not(debug))));
 }
 
@@ -116,6 +134,23 @@ impl BitPacker for BitPacker4x {
         }
     }
 
+    fn compress_strictly_sorted(
+        &self,
+        initial: Option<u32>,
+        decompressed: &[u32],
+        compressed: &mut [u8],
+        num_bits: u8,
+    ) -> usize {
+        unsafe {
+            scalar::UnsafeBitPackerImpl::compress_strictly_sorted(
+                initial,
+                decompressed,
+                compressed,
+                num_bits,
+            )
+        }
+    }
+
     fn decompress(&self, compressed: &[u8], decompressed: &mut [u32], num_bits: u8) -> usize {
         unsafe { scalar::UnsafeBitPackerImpl::decompress(compressed, decompressed, num_bits) }
     }
@@ -137,11 +172,32 @@ impl BitPacker for BitPacker4x {
         }
     }
 
+    fn decompress_strictly_sorted(
+        &self,
+        initial: Option<u32>,
+        compressed: &[u8],
+        decompressed: &mut [u32],
+        num_bits: u8,
+    ) -> usize {
+        unsafe {
+            scalar::UnsafeBitPackerImpl::decompress_strictly_sorted(
+                initial,
+                compressed,
+                decompressed,
+                num_bits,
+            )
+        }
+    }
+
     fn num_bits(&self, decompressed: &[u32]) -> u8 {
         unsafe { scalar::UnsafeBitPackerImpl::num_bits(decompressed) }
     }
 
     fn num_bits_sorted(&self, initial: u32, decompressed: &[u32]) -> u8 {
         unsafe { scalar::UnsafeBitPackerImpl::num_bits_sorted(initial, decompressed) }
+    }
+
+    fn num_bits_strictly_sorted(&self, initial: Option<u32>, decompressed: &[u32]) -> u8 {
+        unsafe { scalar::UnsafeBitPackerImpl::num_bits_strictly_sorted(initial, decompressed) }
     }
 }

--- a/src/bitpacking_bench.rs
+++ b/src/bitpacking_bench.rs
@@ -19,9 +19,19 @@ fn integrate_data(initial: u32, data: &mut [u32]) {
     }
 }
 
+fn strict_integrate_data(initial: Option<u32>, data: &mut [u32]) {
+    let mut cumul = initial.unwrap_or(u32::MAX);
+    let len = data.len();
+    for i in 0..len {
+        cumul = cumul.wrapping_add(data[i]).wrapping_add(1);
+        data[i] = cumul;
+    }
+}
+
 enum DataType {
-    Delta(u32),
     NoDelta,
+    Delta(u32),
+    StrictDelta(Option<u32>),
 }
 
 fn create_array(block_len: usize, num_bits_arr: &[u8], data_type: DataType) -> Vec<u32> {
@@ -32,8 +42,10 @@ fn create_array(block_len: usize, num_bits_arr: &[u8], data_type: DataType) -> V
             original_values.push(val);
         }
     }
-    if let DataType::Delta(initial) = data_type {
-        integrate_data(initial, &mut original_values);
+    match data_type {
+        DataType::NoDelta => (),
+        DataType::Delta(initial) => integrate_data(initial, &mut original_values),
+        DataType::StrictDelta(initial) => strict_integrate_data(initial, &mut original_values),
     }
     original_values
 }
@@ -98,7 +110,12 @@ fn bench_decompress_delta_util<TBitPacker: BitPacker + 'static>(
     num_bits_arr: &[u8],
 ) {
     let num_blocks = num_bits_arr.len();
-    let original_values = create_array(TBitPacker::BLOCK_LEN, &num_bits_arr, DataType::Delta(3u32));
+    let initial_value = 3u32;
+    let original_values = create_array(
+        TBitPacker::BLOCK_LEN,
+        &num_bits_arr,
+        DataType::Delta(initial_value),
+    );
     let mut compressed = vec![0u8; original_values.len() * 4];
     let mut num_bits_vec = Vec::with_capacity(num_bits_arr.len());
     let mut offset = 0;
@@ -106,9 +123,9 @@ fn bench_decompress_delta_util<TBitPacker: BitPacker + 'static>(
         let start = i * TBitPacker::BLOCK_LEN;
         let stop = start + TBitPacker::BLOCK_LEN;
         let block = &original_values[start..stop];
-        let num_bits = bitpacker.num_bits(block);
+        let num_bits = bitpacker.num_bits_sorted(initial_value, block);
         num_bits_vec.push(num_bits);
-        bitpacker.compress(block, &mut compressed[offset..], num_bits);
+        bitpacker.compress_sorted(initial_value, block, &mut compressed[offset..], num_bits);
         offset += (num_bits as usize) * TBitPacker::BLOCK_LEN / 8;
     }
     let mut result: Vec<u32> = vec![0u32; original_values.len()];
@@ -116,7 +133,7 @@ fn bench_decompress_delta_util<TBitPacker: BitPacker + 'static>(
         let mut offset = 0;
         for (i, num_bits) in num_bits_vec.iter().cloned().enumerate() {
             let dest_block = &mut result[i * TBitPacker::BLOCK_LEN..][..TBitPacker::BLOCK_LEN];
-            bitpacker.decompress(&compressed[offset..], dest_block, num_bits);
+            bitpacker.decompress_sorted(initial_value, &compressed[offset..], dest_block, num_bits);
             offset += (num_bits as usize) * TBitPacker::BLOCK_LEN / 8;
         }
     });
@@ -141,6 +158,80 @@ fn bench_compress_delta_util<TBitPacker: BitPacker + 'static>(
             let stride = TBitPacker::BLOCK_LEN * (num_bits as usize) / 8;
             num_bits_vec.push(num_bits);
             bitpacker.compress_sorted(3u32, block, &mut compress[offset..], num_bits);
+            offset += stride;
+        }
+    });
+}
+
+fn bench_decompress_strict_delta_util<TBitPacker: BitPacker + 'static>(
+    bitpacker: TBitPacker,
+    bencher: &mut Bencher,
+    num_bits_arr: &[u8],
+) {
+    let num_blocks = num_bits_arr.len();
+    let initial_value = Some(3u32);
+    let original_values = create_array(
+        TBitPacker::BLOCK_LEN,
+        &num_bits_arr,
+        DataType::StrictDelta(initial_value),
+    );
+    let mut compressed = vec![0u8; original_values.len() * 4];
+    let mut num_bits_vec = Vec::with_capacity(num_bits_arr.len());
+    let mut offset = 0;
+    for i in 0..num_blocks {
+        let start = i * TBitPacker::BLOCK_LEN;
+        let stop = start + TBitPacker::BLOCK_LEN;
+        let block = &original_values[start..stop];
+        let num_bits = bitpacker.num_bits_strictly_sorted(initial_value, block);
+        num_bits_vec.push(num_bits);
+        bitpacker.compress_strictly_sorted(
+            initial_value,
+            block,
+            &mut compressed[offset..],
+            num_bits,
+        );
+        offset += (num_bits as usize) * TBitPacker::BLOCK_LEN / 8;
+    }
+    let mut result: Vec<u32> = vec![0u32; original_values.len()];
+    bencher.iter(|| {
+        let mut offset = 0;
+        for (i, num_bits) in num_bits_vec.iter().cloned().enumerate() {
+            let dest_block = &mut result[i * TBitPacker::BLOCK_LEN..][..TBitPacker::BLOCK_LEN];
+            bitpacker.decompress_strictly_sorted(
+                initial_value,
+                &compressed[offset..],
+                dest_block,
+                num_bits,
+            );
+            offset += (num_bits as usize) * TBitPacker::BLOCK_LEN / 8;
+        }
+    });
+}
+
+fn bench_compress_strict_delta_util<TBitPacker: BitPacker + 'static>(
+    bitpacker: TBitPacker,
+    bencher: &mut Bencher,
+    num_bits_arr: &[u8],
+) {
+    let num_blocks = num_bits_arr.len();
+    let initial = Some(3u32);
+    let original_values = create_array(
+        TBitPacker::BLOCK_LEN,
+        num_bits_arr,
+        DataType::StrictDelta(initial),
+    );
+    let mut compress = vec![0u8; original_values.len() * 4];
+    let mut num_bits_vec = Vec::with_capacity(num_bits_arr.len());
+    bencher.iter(|| {
+        let mut offset = 0;
+        for i in 0..num_blocks {
+            let start = i * TBitPacker::BLOCK_LEN;
+            let stop = start + TBitPacker::BLOCK_LEN;
+            let block = &original_values[start..stop];
+            let num_bits = bitpacker.num_bits(block);
+            let stride = TBitPacker::BLOCK_LEN * (num_bits as usize) / 8;
+            num_bits_vec.push(num_bits);
+            bitpacker.compress_strictly_sorted(initial, block, &mut compress[offset..], num_bits);
             offset += stride;
         }
     });
@@ -173,6 +264,18 @@ fn criterion_benchmark_bitpacker<TBitPacker: BitPacker + 'static>(
         );
         criterion.bench(
             name,
+            Benchmark::new(
+                format!("decompress-strict-delta-{}", num_bit).as_str(),
+                move |b| {
+                    bench_decompress_strict_delta_util::<TBitPacker>(bitpacker, b, &num_bits[..]);
+                },
+            )
+            .throughput(Throughput::Elements(
+                (NUM_BLOCKS * TBitPacker::BLOCK_LEN) as u64,
+            )),
+        );
+        criterion.bench(
+            name,
             Benchmark::new(format!("compress-{}", num_bit).as_str(), move |b| {
                 bench_compress_util::<TBitPacker>(bitpacker, b, &num_bits[..]);
             })
@@ -185,6 +288,18 @@ fn criterion_benchmark_bitpacker<TBitPacker: BitPacker + 'static>(
             Benchmark::new(format!("compress-delta-{}", num_bit).as_str(), move |b| {
                 bench_compress_delta_util::<TBitPacker>(bitpacker, b, &num_bits[..]);
             })
+            .throughput(Throughput::Elements(
+                (NUM_BLOCKS * TBitPacker::BLOCK_LEN) as u64,
+            )),
+        );
+        criterion.bench(
+            name,
+            Benchmark::new(
+                format!("compress-strict-delta-{}", num_bit).as_str(),
+                move |b| {
+                    bench_compress_strict_delta_util::<TBitPacker>(bitpacker, b, &num_bits[..]);
+                },
+            )
             .throughput(Throughput::Elements(
                 (NUM_BLOCKS * TBitPacker::BLOCK_LEN) as u64,
             )),


### PR DESCRIPTION
part of https://github.com/quickwit-oss/quickwit/issues/3740

also make bitpacker4x tests run properly (before, only bitpacker4x_simple would get run consistently, and `test_compatible_sse3` wouldn't run at all), and fix a bug in the decompress-delta benchmark, where it would actually use the non-delta codec