### PR TITLE
A few small lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ crunchy = "0.2"
 
 [dev-dependencies]
 rand = "0.8"
-criterion = "0.3"
-proptest = "1.0.0"
+criterion = { version = "0.3", features = ["html_reports"] }
+proptest = "1.4"
 
 [features]
 bitpacker1x = []

--- a/src/bitpacker4x.rs
+++ b/src/bitpacker4x.rs
@@ -8,7 +8,7 @@ use crate::Available;
 
 const BLOCK_LEN: usize = 32 * 4;
 
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 mod sse3 {
 
     use super::BLOCK_LEN;

--- a/src/bitpacker8x.rs
+++ b/src/bitpacker8x.rs
@@ -61,7 +61,7 @@ mod avx2 {
             _mm256_add_epi32(___a__b__ca____e__f__ge_, a__b__ca_db_e__f__ge_fh_);
         let offseted_halved_prefix_sum = _mm256_add_epi32(halved_prefix_sum, offset);
         let select_last_low = _mm256_shuffle_epi32(offseted_halved_prefix_sum, 0xff);
-        let high_offset = _mm256_permute2f128_si256(select_last_low, select_last_low, 8);
+        let high_offset = _mm256_permute2f128_si256(select_last_low, select_last_low, 8 | 0);
         _mm256_add_epi32(high_offset, offseted_halved_prefix_sum)
     }
 

--- a/src/bitpacker8x.rs
+++ b/src/bitpacker8x.rs
@@ -61,7 +61,7 @@ mod avx2 {
             _mm256_add_epi32(___a__b__ca____e__f__ge_, a__b__ca_db_e__f__ge_fh_);
         let offseted_halved_prefix_sum = _mm256_add_epi32(halved_prefix_sum, offset);
         let select_last_low = _mm256_shuffle_epi32(offseted_halved_prefix_sum, 0xff);
-        let high_offset = _mm256_permute2f128_si256(select_last_low, select_last_low, 8 | 0);
+        let high_offset = _mm256_permute2f128_si256(select_last_low, select_last_low, 8);
         _mm256_add_epi32(high_offset, offseted_halved_prefix_sum)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,6 @@ trait UnsafeBitPacker {
 
 /// # Examples without delta-encoding
 /// ```
-/// extern crate bitpacking;
-///
 /// use bitpacking::{BitPacker4x, BitPacker};
 ///
 /// # fn main() {
@@ -118,8 +116,6 @@ trait UnsafeBitPacker {
 /// integration or prefix sum) on them.
 ///
 /// ```
-/// extern crate bitpacking;
-///
 /// use bitpacking::{BitPacker4x, BitPacker};
 ///
 /// # fn main() {
@@ -325,6 +321,7 @@ pub trait BitPacker: Sized + Clone + Copy {
     fn num_bits_strictly_sorted(&self, initial: Option<u32>, decompressed: &[u32]) -> u8;
 
     /// Returns the size of a compressed block.
+    #[must_use]
     fn compressed_block_size(num_bits: u8) -> usize {
         Self::BLOCK_LEN * (num_bits as usize) / 8
     }
@@ -413,7 +410,7 @@ mod functional_tests {
         #[test]
         fn check_sorted_block(
             (values, init_value) in prop::collection::vec(u32::arbitrary(), BitPacker4x::BLOCK_LEN).prop_flat_map(|mut values| {
-                values.sort();
+                values.sort_unstable();
                 let min_value = values[0];
                 (Just(values), (0..=min_value))
             }),


### PR DESCRIPTION
* style fixes in the readme
* grammar fixes in readme
* use `.copied()` instead of `.cloned()` for simple values
* remove all `extern` -- they are not needed in 2021 edition